### PR TITLE
du_paragraphs - New/Missing Config and .install files

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -75,7 +75,9 @@
         "drupal/dynamic_entity_reference": "^3.2",
         "drupal/draggableviews": "^2.1",
         "drupal/structure_sync": "^2.0",
-        "drupal/charts": "^5.0"
+        "drupal/charts": "^5.0",
+        "drupal/menu_item_extras": "^3.0",
+        "university-of-denver/du_bootstrap": "^1.0.0"
     },
     "extra": {
         "_README": "To make a custom upstream, clone this repository and add any dependencies to be provided by this upstream to this composer.json file. Leave the root-level composer.json file for the exclusive use of each individual site; do not modify it after your custom upstream has been published. See https://pantheon.io/docs/create-custom-upstream for more information."

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.category_link.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.category_link.default.yml
@@ -1,0 +1,70 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.browse_files_modal
+    - field.field.paragraph.category_link.field_color
+    - field.field.paragraph.category_link.field_icon
+    - field.field.paragraph.category_link.field_link
+    - paragraphs.paragraphs_type.category_link
+  module:
+    - entity_browser
+    - link_attributes
+_core:
+  default_config_hash: W7B6mKuv1QMYJTclso0J0rvNugzH36fUwbVnZ6MLQWU
+id: paragraph.category_link.default
+targetEntityType: paragraph
+bundle: category_link
+mode: default
+content:
+  field_icon:
+    type: entity_browser_file
+    weight: 1
+    region: content
+    settings:
+      entity_browser: browse_files_modal
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      selection_mode: selection_append
+      view_mode: default
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_link:
+    type: link_attributes
+    weight: 0
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      enabled_attributes:
+        onClick: true
+        fragment: true
+        target: true
+        aria-label: true
+        title: false
+        data-toggle: false
+        id: false
+        name: false
+        rel: false
+        class: false
+        accesskey: false
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduled_publication:
+    type: datetime_default
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_color: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.cta.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.cta.default.yml
@@ -1,0 +1,103 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.browse_files_modal
+    - field.field.paragraph.cta.field_cta_bg_image
+    - field.field.paragraph.cta.field_cta_color
+    - field.field.paragraph.cta.field_cta_style
+    - field.field.paragraph.cta.field_headline
+    - field.field.paragraph.cta.field_link
+    - field.field.paragraph.cta.field_subhead_long
+    - paragraphs.paragraphs_type.cta
+  module:
+    - content_moderation
+    - datetime
+    - entity_browser
+    - link_attributes
+    - text
+_core:
+  default_config_hash: '-rwd2ofXI1RvRZiS-rMovUFxb8_5h9ycBYM3Qkyczpo'
+id: paragraph.cta.default
+targetEntityType: paragraph
+bundle: cta
+mode: default
+content:
+  field_cta_bg_image:
+    type: entity_browser_file
+    weight: 4
+    region: content
+    settings:
+      entity_browser: browse_files_modal
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      selection_mode: selection_append
+      view_mode: default
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_cta_color:
+    type: options_select
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_cta_style:
+    type: options_select
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_headline:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_link:
+    type: link_attributes
+    weight: 3
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      enabled_attributes:
+        onClick: true
+        fragment: true
+        target: true
+        aria-label: true
+        title: false
+        data-toggle: false
+        id: false
+        name: false
+        rel: false
+        class: false
+        accesskey: false
+    third_party_settings: {  }
+  field_subhead_long:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduled_publication:
+    type: datetime_default
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.cta_inline.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.cta_inline.default.yml
@@ -1,0 +1,62 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cta_inline.field_cta_inline_headline
+    - field.field.paragraph.cta_inline.field_link
+    - paragraphs.paragraphs_type.cta_inline
+  module:
+    - content_moderation
+    - datetime
+    - link_attributes
+_core:
+  default_config_hash: GiNtSyqNatONzR3iWRWzU0Rv968bwupC7-Iqf6Yak_w
+id: paragraph.cta_inline.default
+targetEntityType: paragraph
+bundle: cta_inline
+mode: default
+content:
+  field_cta_inline_headline:
+    type: string_textfield
+    weight: 103
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_link:
+    type: link_attributes
+    weight: 104
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      enabled_attributes:
+        onClick: true
+        fragment: true
+        target: true
+        rel: true
+        class: true
+        aria-label: true
+        title: false
+        data-toggle: false
+        id: false
+        name: false
+        accesskey: false
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduled_publication:
+    type: datetime_default
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.feature_media_image.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.feature_media_image.default.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.browse_files_modal
+    - field.field.paragraph.feature_media_image.field_feature_media_image
+    - paragraphs.paragraphs_type.feature_media_image
+  module:
+    - content_moderation
+    - datetime
+    - entity_browser
+_core:
+  default_config_hash: XSo8atxfl5wZLWDcWJ9H8jJwh6v_LEX3Da_bmTrsnJg
+id: paragraph.feature_media_image.default
+targetEntityType: paragraph
+bundle: feature_media_image
+mode: default
+content:
+  field_feature_media_image:
+    type: entity_browser_file
+    weight: 101
+    region: content
+    settings:
+      entity_browser: browse_files_modal
+      field_widget_edit: true
+      field_widget_remove: true
+      open: false
+      selection_mode: selection_append
+      view_mode: default
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduled_publication:
+    type: datetime_default
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.hero_media.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.hero_media.default.yml
@@ -1,0 +1,136 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.browse_files_modal
+    - field.field.paragraph.hero_media.field_headline
+    - field.field.paragraph.hero_media.field_hero_caption
+    - field.field.paragraph.hero_media.field_hero_embed
+    - field.field.paragraph.hero_media.field_hero_image
+    - field.field.paragraph.hero_media.field_hero_video
+    - field.field.paragraph.hero_media.field_image_type
+    - field.field.paragraph.hero_media.field_subhead
+    - paragraphs.paragraphs_type.hero_media
+  module:
+    - entity_browser
+    - field_group
+    - text
+third_party_settings:
+  field_group:
+    group_hero_caption:
+      children: {  }
+      label: 'Hero Caption'
+      region: hidden
+      parent_name: ''
+      weight: 9
+      format_type: details
+      format_settings:
+        classes: ''
+        id: ''
+        open: false
+        required_fields: false
+    group_headlines:
+      children:
+        - field_headline
+        - field_subhead
+      label: Headlines
+      region: content
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        classes: ''
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+_core:
+  default_config_hash: eBCPWghpbBu2lXVBP3r0hA8utlw2pC5WNRtOIZG0J0E
+id: paragraph.hero_media.default
+targetEntityType: paragraph
+bundle: hero_media
+mode: default
+content:
+  field_headline:
+    type: string_textfield
+    weight: 5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_hero_caption:
+    type: text_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_hero_embed:
+    type: text_textarea
+    weight: 10
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_hero_image:
+    type: entity_browser_file
+    weight: 1
+    region: content
+    settings:
+      entity_browser: browse_files_modal
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: false
+      selection_mode: selection_append
+      view_mode: default
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_hero_video:
+    type: entity_browser_file
+    weight: 2
+    region: content
+    settings:
+      entity_browser: browse_files_modal
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: false
+      selection_mode: selection_append
+      view_mode: default
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_image_type:
+    type: boolean_checkbox
+    weight: 0
+    region: content
+    settings:
+      display_label: false
+    third_party_settings: {  }
+  field_subhead:
+    type: string_textfield
+    weight: 6
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduled_publication:
+    type: datetime_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.icon_link.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.icon_link.default.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.icon_link.field_du_icon
+    - field.field.paragraph.icon_link.field_icon_link_link
+    - paragraphs.paragraphs_type.icon_link
+  module:
+    - content_moderation
+    - datetime
+    - link_attributes
+_core:
+  default_config_hash: R4RPWAbxTAC9utztqQerSVBR4Q6h3vLHYNjLlEzcc3U
+id: paragraph.icon_link.default
+targetEntityType: paragraph
+bundle: icon_link
+mode: default
+content:
+  field_du_icon:
+    type: options_select
+    weight: 101
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_icon_link_link:
+    type: link_attributes
+    weight: 102
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      enabled_attributes:
+        onClick: true
+        fragment: true
+        target: true
+        rel: true
+        class: true
+        aria-label: true
+        title: false
+        data-toggle: false
+        id: false
+        name: false
+        accesskey: false
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduled_publication:
+    type: datetime_default
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.icon_list.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.icon_list.default.yml
@@ -1,0 +1,51 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.icon_list.field_icon_list_items
+    - field.field.paragraph.icon_list.field_icon_list_items_small
+    - paragraphs.paragraphs_type.icon_list
+  module:
+    - paragraphs
+_core:
+  default_config_hash: E7SiXV9CLUmgDQOK64urwq4humupWYEMxsmeb2mIdMA
+id: paragraph.icon_list.default
+targetEntityType: paragraph
+bundle: icon_list
+mode: default
+content:
+  field_icon_list_items:
+    type: entity_reference_paragraphs
+    weight: 1
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+  field_icon_list_items_small:
+    type: boolean_checkbox
+    weight: 0
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduled_publication:
+    type: datetime_default
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.image_with_caption.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.image_with_caption.default.yml
@@ -1,0 +1,65 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.browse_files_modal
+    - field.field.paragraph.image_with_caption.field_image_caption_alignment
+    - field.field.paragraph.image_with_caption.field_image_caption_caption
+    - field.field.paragraph.image_with_caption.field_image_caption_float
+    - field.field.paragraph.image_with_caption.field_image_caption_image
+    - paragraphs.paragraphs_type.image_with_caption
+  module:
+    - content_moderation
+    - entity_browser
+    - text
+_core:
+  default_config_hash: Ww8iJZgdV2sEodqHpm0IBpkIQRzXeKM1AAi1HoIOGY8
+id: paragraph.image_with_caption.default
+targetEntityType: paragraph
+bundle: image_with_caption
+mode: default
+content:
+  field_image_caption_alignment:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_image_caption_caption:
+    type: text_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_image_caption_float:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_image_caption_image:
+    type: entity_browser_file
+    weight: 3
+    region: content
+    settings:
+      entity_browser: browse_files_modal
+      field_widget_edit: true
+      field_widget_remove: true
+      open: false
+      selection_mode: selection_append
+      view_mode: default
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.inset_video.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.inset_video.default.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.inset_video.field_inset_video_youtube_video
+    - paragraphs.paragraphs_type.inset_video
+  module:
+    - video_embed_field
+_core:
+  default_config_hash: G-y359l5Xb7ndUhIedmKsZ0Y2B20Flg8ZwxAmpNOMLc
+id: paragraph.inset_video.default
+targetEntityType: paragraph
+bundle: inset_video
+mode: default
+content:
+  field_inset_video_youtube_video:
+    type: video_embed_field_textfield
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  moderation_state: true
+  scheduled_publication: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.list_of_links.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.list_of_links.default.yml
@@ -1,0 +1,69 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.list_of_links.field_list_of_links
+    - field.field.paragraph.list_of_links.field_list_of_links_layout
+    - field.field.paragraph.list_of_links.field_list_of_links_style
+    - paragraphs.paragraphs_type.list_of_links
+  module:
+    - field_group
+    - link_attributes
+third_party_settings:
+  field_group:
+    group_list_of_links_links:
+      children:
+        - field_list_of_links
+      label: Links
+      parent_name: ''
+      weight: 2
+      format_type: details
+      format_settings:
+        classes: ''
+        id: ''
+        open: false
+        required_fields: false
+_core:
+  default_config_hash: fwoE0FzcHkYXf0HDm9Cjc1lA0hc-yf6As_QGcABQ6gs
+id: paragraph.list_of_links.default
+targetEntityType: paragraph
+bundle: list_of_links
+mode: default
+content:
+  field_list_of_links:
+    type: link_attributes
+    weight: 3
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      enabled_attributes:
+        onClick: true
+        fragment: true
+        target: true
+        aria-label: true
+        title: false
+        id: false
+        name: false
+        rel: false
+        class: false
+        accesskey: false
+    third_party_settings: {  }
+  field_list_of_links_layout:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_list_of_links_style:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  moderation_state: true
+  scheduled_publication: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.named_anchor.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.named_anchor.default.yml
@@ -1,0 +1,40 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.named_anchor.field_named_anchor_name
+    - paragraphs.paragraphs_type.named_anchor
+  module:
+    - content_moderation
+    - datetime
+_core:
+  default_config_hash: sCidI5GijobDUd17B-I5ChuoF-3KxzJZ1TMxaJO5X4s
+id: paragraph.named_anchor.default
+targetEntityType: paragraph
+bundle: named_anchor
+mode: default
+content:
+  field_named_anchor_name:
+    type: string_textfield
+    weight: 101
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduled_publication:
+    type: datetime_default
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.reusable_content.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.reusable_content.default.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.reusable_content.field_reusable_content
+    - paragraphs.paragraphs_type.reusable_content
+id: paragraph.reusable_content.default
+targetEntityType: paragraph
+bundle: reusable_content
+mode: default
+content:
+  field_reusable_content:
+    type: entity_reference_autocomplete
+    weight: 0
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.unit_carousel.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.unit_carousel.default.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.unit_carousel.field_unit_carousel_slide
+    - field.field.paragraph.unit_carousel.field_unit_carousel_title
+    - paragraphs.paragraphs_type.unit_carousel
+  module:
+    - content_moderation
+    - paragraphs
+_core:
+  default_config_hash: Up3dneCh3RYBRXgaEPXHQ-zv_na-3IP-sAZUlj0H25w
+id: paragraph.unit_carousel.default
+targetEntityType: paragraph
+bundle: unit_carousel
+mode: default
+content:
+  field_unit_carousel_slide:
+    type: entity_reference_paragraphs
+    weight: 2
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: unit_slide
+    third_party_settings: {  }
+  field_unit_carousel_title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.unit_hero_media_.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_form_display.paragraph.unit_hero_media_.default.yml
@@ -1,0 +1,113 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.browse_files_modal
+    - field.field.paragraph.unit_hero_media_.field_hero_image
+    - field.field.paragraph.unit_hero_media_.field_hero_video
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_caption
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_display
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_embed
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_headline
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_link
+    - field.field.paragraph.unit_hero_media_.field_unit_image_type
+    - paragraphs.paragraphs_type.unit_hero_media_
+  module:
+    - entity_browser
+    - link_attributes
+    - text
+id: paragraph.unit_hero_media_.default
+targetEntityType: paragraph
+bundle: unit_hero_media_
+mode: default
+content:
+  field_hero_image:
+    type: entity_browser_file
+    weight: 4
+    region: content
+    settings:
+      entity_browser: browse_files_modal
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: false
+      selection_mode: selection_append
+      view_mode: default
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_hero_video:
+    type: entity_browser_file
+    weight: 5
+    region: content
+    settings:
+      entity_browser: browse_files_modal
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: false
+      selection_mode: selection_append
+      view_mode: default
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_unit_hero_caption:
+    type: string_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_unit_hero_display:
+    type: options_select
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_unit_hero_embed:
+    type: text_textarea
+    weight: 7
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_unit_hero_headline:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_unit_hero_link:
+    type: link_attributes
+    weight: 6
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      enabled_attributes:
+        onClick: true
+        title: true
+        target: true
+        data-toggle: false
+        fragment: false
+        id: false
+        name: false
+        rel: false
+        class: false
+        accesskey: false
+        aria-label: false
+    third_party_settings: {  }
+  field_unit_image_type:
+    type: boolean_checkbox
+    weight: 0
+    region: content
+    settings:
+      display_label: false
+    third_party_settings: {  }
+hidden:
+  created: true
+  moderation_state: true
+  status: true
+  uid: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.category_link.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.category_link.default.yml
@@ -1,0 +1,58 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.category_link.field_color
+    - field.field.paragraph.category_link.field_icon
+    - field.field.paragraph.category_link.field_link
+    - paragraphs.paragraphs_type.category_link
+  module:
+    - du_site
+    - image
+    - link
+    - options
+_core:
+  default_config_hash: ELfmHu2nlOoOPrG4c5u7KbpHsFxtS2nEgQa2ls961ss
+id: paragraph.category_link.default
+targetEntityType: paragraph
+bundle: category_link
+mode: default
+content:
+  field_color:
+    type: list_key
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_icon:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: ''
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_link:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings:
+      du_site:
+        list_of_links: ''
+    weight: 2
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.cta.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.cta.default.yml
@@ -1,0 +1,76 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cta.field_cta_bg_image
+    - field.field.paragraph.cta.field_cta_color
+    - field.field.paragraph.cta.field_cta_style
+    - field.field.paragraph.cta.field_headline
+    - field.field.paragraph.cta.field_link
+    - field.field.paragraph.cta.field_subhead_long
+    - paragraphs.paragraphs_type.cta
+    - responsive_image.styles.cta_module_narrow
+  module:
+    - link
+    - options
+    - responsive_image
+    - text
+_core:
+  default_config_hash: 7_YVasdtjETgOeOtj7bL_hIB9cGP_BEnpCiAdhFfnRU
+id: paragraph.cta.default
+targetEntityType: paragraph
+bundle: cta
+mode: default
+content:
+  field_cta_bg_image:
+    type: responsive_image
+    label: hidden
+    settings:
+      responsive_image_style: cta_module_narrow
+      image_link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_cta_color:
+    type: list_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_cta_style:
+    type: list_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_headline:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_subhead_long:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.cta_inline.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.cta_inline.default.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cta_inline.field_cta_inline_headline
+    - field.field.paragraph.cta_inline.field_link
+    - paragraphs.paragraphs_type.cta_inline
+  module:
+    - link
+_core:
+  default_config_hash: B6YewopwfI9ssOUALJDgLj1TfmwoxgmkywmH3Z7ufDw
+id: paragraph.cta_inline.default
+targetEntityType: paragraph
+bundle: cta_inline
+mode: default
+content:
+  field_cta_inline_headline:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.feature_media_image.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.feature_media_image.default.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.feature_media_image.field_feature_media_image
+    - paragraphs.paragraphs_type.feature_media_image
+    - responsive_image.styles.feature_media_image
+  module:
+    - responsive_image
+_core:
+  default_config_hash: M_0Q5NuOssv5Jibs8ypGHtfRuyoj7_rj0-TpZ3mxpmo
+id: paragraph.feature_media_image.default
+targetEntityType: paragraph
+bundle: feature_media_image
+mode: default
+content:
+  field_feature_media_image:
+    type: responsive_image
+    label: hidden
+    settings:
+      responsive_image_style: feature_media_image
+      image_link: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.hero_media.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.hero_media.default.yml
@@ -1,0 +1,82 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hero_media.field_headline
+    - field.field.paragraph.hero_media.field_hero_caption
+    - field.field.paragraph.hero_media.field_hero_embed
+    - field.field.paragraph.hero_media.field_hero_image
+    - field.field.paragraph.hero_media.field_hero_video
+    - field.field.paragraph.hero_media.field_image_type
+    - field.field.paragraph.hero_media.field_subhead
+    - paragraphs.paragraphs_type.hero_media
+    - responsive_image.styles.hero_image
+  module:
+    - file
+    - responsive_image
+    - text
+_core:
+  default_config_hash: '-0rqqRDZEREMG3bWLsy3d0WdGhOLghFB0MG5-XOGVes'
+id: paragraph.hero_media.default
+targetEntityType: paragraph
+bundle: hero_media
+mode: default
+content:
+  field_headline:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_hero_caption:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_hero_embed:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_hero_image:
+    type: responsive_image
+    label: above
+    settings:
+      responsive_image_style: hero_image
+      image_link: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_hero_video:
+    type: file_url_plain
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_image_type:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_subhead:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.icon_link.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.icon_link.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.icon_link.field_du_icon
+    - field.field.paragraph.icon_link.field_icon_link_link
+    - paragraphs.paragraphs_type.icon_link
+  module:
+    - du_site
+    - link
+    - options
+_core:
+  default_config_hash: mnK2DSEE4REUuZPWh59chJFIt0a9cnUfyoHKyXVgeFY
+id: paragraph.icon_link.default
+targetEntityType: paragraph
+bundle: icon_link
+mode: default
+content:
+  field_du_icon:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_icon_link_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings:
+      du_site:
+        list_of_links: ''
+    weight: 1
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.icon_list.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.icon_list.default.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.icon_list.field_icon_list_items
+    - field.field.paragraph.icon_list.field_icon_list_items_small
+    - paragraphs.paragraphs_type.icon_list
+  module:
+    - entity_reference_revisions
+_core:
+  default_config_hash: 6m36QzVpRbeO-e6wCeR6DBS1qWWu5sKD9XAW22XGTwo
+id: paragraph.icon_list.default
+targetEntityType: paragraph
+bundle: icon_list
+mode: default
+content:
+  field_icon_list_items:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_icon_list_items_small:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.image_with_caption.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.image_with_caption.default.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.image_with_caption.field_image_caption_alignment
+    - field.field.paragraph.image_with_caption.field_image_caption_caption
+    - field.field.paragraph.image_with_caption.field_image_caption_float
+    - field.field.paragraph.image_with_caption.field_image_caption_image
+    - paragraphs.paragraphs_type.image_with_caption
+  module:
+    - image
+    - options
+    - text
+_core:
+  default_config_hash: wNrqP_lU15YtXWO5JND_u_k8xviIpD5MWsfnKkU_9nU
+id: paragraph.image_with_caption.default
+targetEntityType: paragraph
+bundle: image_with_caption
+mode: default
+content:
+  field_image_caption_alignment:
+    type: list_key
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_image_caption_caption:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_image_caption_float:
+    type: boolean
+    label: above
+    settings:
+      format: boolean
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_image_caption_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.inset_video.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.inset_video.default.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.inset_video.field_inset_video_youtube_video
+    - paragraphs.paragraphs_type.inset_video
+  module:
+    - video_embed_field
+_core:
+  default_config_hash: 4suPl-R7ijgULTa9GWVZ2oP0xGwa8lwnIGxcIxNnEII
+id: paragraph.inset_video.default
+targetEntityType: paragraph
+bundle: inset_video
+mode: default
+content:
+  field_inset_video_youtube_video:
+    type: video_embed_field_video
+    label: above
+    settings:
+      autoplay: false
+      responsive: false
+      width: 560
+      height: 315
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.list_of_links.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.list_of_links.default.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.list_of_links.field_list_of_links
+    - field.field.paragraph.list_of_links.field_list_of_links_layout
+    - field.field.paragraph.list_of_links.field_list_of_links_style
+    - paragraphs.paragraphs_type.list_of_links
+  module:
+    - du_site
+    - link
+    - options
+_core:
+  default_config_hash: EVvCXmAdsoUynMS41dv2iUtJBPB5Bh_s7p0yutlCqXY
+id: paragraph.list_of_links.default
+targetEntityType: paragraph
+bundle: list_of_links
+mode: default
+content:
+  field_list_of_links:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings:
+      du_site:
+        list_of_links: ''
+    weight: 0
+    region: content
+  field_list_of_links_layout:
+    type: list_key
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_list_of_links_style:
+    type: list_key
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.named_anchor.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.named_anchor.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.named_anchor.field_named_anchor_name
+    - paragraphs.paragraphs_type.named_anchor
+_core:
+  default_config_hash: hxubJ2mDJFeSFasX1QCJc9C7LQaWhEdVslOKad4hK6o
+id: paragraph.named_anchor.default
+targetEntityType: paragraph
+bundle: named_anchor
+mode: default
+content:
+  field_named_anchor_name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  scheduled_publication: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.reusable_content.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.reusable_content.default.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.reusable_content.field_reusable_content
+    - paragraphs.paragraphs_type.reusable_content
+id: paragraph.reusable_content.default
+targetEntityType: paragraph
+bundle: reusable_content
+mode: default
+content:
+  field_reusable_content:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.unit_carousel.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.unit_carousel.default.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.unit_carousel.field_unit_carousel_slide
+    - field.field.paragraph.unit_carousel.field_unit_carousel_title
+    - paragraphs.paragraphs_type.unit_carousel
+  module:
+    - entity_reference_revisions
+_core:
+  default_config_hash: uBdbTPgY82MzICGPJA6S8AOpkl14wyUGvhKLu5SIUUM
+id: paragraph.unit_carousel.default
+targetEntityType: paragraph
+bundle: unit_carousel
+mode: default
+content:
+  field_unit_carousel_slide:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_unit_carousel_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.unit_hero_media_.default.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/core.entity_view_display.paragraph.unit_hero_media_.default.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.unit_hero_media_.field_hero_image
+    - field.field.paragraph.unit_hero_media_.field_hero_video
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_caption
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_display
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_embed
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_headline
+    - field.field.paragraph.unit_hero_media_.field_unit_hero_link
+    - field.field.paragraph.unit_hero_media_.field_unit_image_type
+    - paragraphs.paragraphs_type.unit_hero_media_
+  module:
+    - text
+id: paragraph.unit_hero_media_.default
+targetEntityType: paragraph
+bundle: unit_hero_media_
+mode: default
+content:
+  field_unit_hero_embed:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_unit_image_type:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_hero_image: true
+  field_hero_video: true
+  field_unit_hero_caption: true
+  field_unit_hero_display: true
+  field_unit_hero_headline: true
+  field_unit_hero_link: true

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.cta.field_subhead_long.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.cta.field_subhead_long.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_subhead_long
+    - paragraphs.paragraphs_type.cta
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    rich_text: rich_text
+    embed_code: '0'
+    inline_formatting: '0'
+    plain_text: '0'
+_core:
+  default_config_hash: h_xDCuWz1WVsaOC_G3AnHgBqm38wb96QsIZEpwExrTQ
+id: paragraph.cta.field_subhead_long
+field_name: field_subhead_long
+entity_type: paragraph
+bundle: cta
+label: Subhead
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.cta_inline.field_cta_inline_headline.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.cta_inline.field_cta_inline_headline.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_cta_inline_headline
+    - paragraphs.paragraphs_type.cta_inline
+_core:
+  default_config_hash: I5wXSN7PEKcV1Vuuoi_9Gyt9sl72pGU5j5tiHbZuGds
+id: paragraph.cta_inline.field_cta_inline_headline
+field_name: field_cta_inline_headline
+entity_type: paragraph
+bundle: cta_inline
+label: 'CTA Inline Headline'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.cta_inline.field_link.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.cta_inline.field_link.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - paragraphs.paragraphs_type.cta_inline
+  module:
+    - link
+_core:
+  default_config_hash: Oa4gPdy8F579liY_LxE2j8V5ImThvR7_0bV_TwUGoqo
+id: paragraph.cta_inline.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: cta_inline
+label: Button
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.feature_media_image.field_feature_media_image.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.feature_media_image.field_feature_media_image.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_feature_media_image
+    - paragraphs.paragraphs_type.feature_media_image
+  module:
+    - image
+_core:
+  default_config_hash: OtlxrxYxtnKb7Y4Ix3qU8LYBeMMmpc1Uw0eHGmLhtbg
+id: paragraph.feature_media_image.field_feature_media_image
+field_name: field_feature_media_image
+entity_type: paragraph
+bundle: feature_media_image
+label: 'Feature Media Image'
+description: 'Feature Media Image is 1200x801.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: feature-media-image
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.hero_media.field_hero_image.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.hero_media.field_hero_image.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_image
+    - paragraphs.paragraphs_type.hero_media
+  module:
+    - image
+_core:
+  default_config_hash: ioD5W1aVgN14rhe0Aeea-nYZn3e-ULtWN66EicF5cKE
+id: paragraph.hero_media.field_hero_image
+field_name: field_hero_image
+entity_type: paragraph
+bundle: hero_media
+label: 'Hero Image'
+description: 'For non-Utility pages use 1356 x 538 pixels images.\r\nFor Utility pages use 1356 x 393 pixel images. \r\nImages larger than these dimensions will be scaled and cropped to fit.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: '5 MB'
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.hero_media.field_hero_video.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.hero_media.field_hero_video.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hero_video
+    - paragraphs.paragraphs_type.hero_media
+  module:
+    - file
+_core:
+  default_config_hash: wu7wyO1y35ib_i3-e8Yts7UX5kpP27JNQFs-gZWuOsk
+id: paragraph.hero_media.field_hero_video
+field_name: field_hero_video
+entity_type: paragraph
+bundle: hero_media
+label: 'Hero Video'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: mp4
+  max_filesize: ''
+  description_field: false
+field_type: file

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.icon_link.field_du_icon.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.icon_link.field_du_icon.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_du_icon
+    - paragraphs.paragraphs_type.icon_link
+  module:
+    - options
+id: paragraph.icon_link.field_du_icon
+field_name: field_du_icon
+entity_type: paragraph
+bundle: icon_link
+label: 'DU Icon'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.icon_link.field_icon_link_link.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.icon_link.field_icon_link_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_icon_link_link
+    - paragraphs.paragraphs_type.icon_link
+  module:
+    - link
+id: paragraph.icon_link.field_icon_link_link
+field_name: field_icon_link_link
+entity_type: paragraph
+bundle: icon_link
+label: 'Icon Link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.icon_list.field_icon_list_items.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.icon_list.field_icon_list_items.yml
@@ -1,0 +1,143 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_icon_list_items
+    - paragraphs.paragraphs_type.icon_list
+    - paragraphs.paragraphs_type.icon_list_item
+  module:
+    - entity_reference_revisions
+_core:
+  default_config_hash: qxG6iSisyjl1KFFr8bs5mu0Knvg9m3IRD5XGYumbAAU
+id: paragraph.icon_list.field_icon_list_items
+field_name: field_icon_list_items
+entity_type: paragraph
+bundle: icon_list
+label: Items
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      icon_list_item: icon_list_item
+    negate: 0
+    target_bundles_drag_drop:
+      admission_steps:
+        weight: 39
+        enabled: false
+      admission_steps_in_content:
+        weight: 40
+        enabled: false
+      body_copy:
+        weight: 41
+        enabled: false
+      body_text:
+        weight: 42
+        enabled: false
+      card:
+        weight: 43
+        enabled: false
+      cards:
+        weight: 44
+        enabled: false
+      carousel:
+        weight: 45
+        enabled: false
+      cta:
+        weight: 46
+        enabled: false
+      embed_code:
+        weight: 47
+        enabled: false
+      event_list:
+        weight: 48
+        enabled: false
+      event_time_place:
+        weight: 49
+        enabled: false
+      expanding_list:
+        weight: 50
+        enabled: false
+      featured_event:
+        weight: 51
+        enabled: false
+      featured_event_slide:
+        weight: 52
+        enabled: false
+      featured_video_component:
+        weight: 53
+        enabled: false
+      hero_media:
+        weight: 54
+        enabled: false
+      homepage_facts:
+        weight: 55
+        enabled: false
+      homepage_programs_search:
+        weight: 56
+        enabled: false
+      homepage_quote:
+        weight: 57
+        enabled: false
+      homepage_quotes:
+        weight: 58
+        enabled: false
+      homepage_section_copy:
+        weight: 59
+        enabled: false
+      homepage_swapping_image_feature:
+        weight: 60
+        enabled: false
+      homepage_video_carousel:
+        weight: 61
+        enabled: false
+      hvc_slide:
+        weight: 62
+        enabled: false
+      icon_list:
+        weight: 63
+        enabled: false
+      icon_list_item:
+        weight: 64
+        enabled: true
+      inset_video:
+        weight: 65
+        enabled: false
+      quick_facts:
+        weight: 66
+        enabled: false
+      quick_facts_feature_fact:
+        weight: 67
+        enabled: false
+      quick_facts_list_item_simple:
+        weight: 68
+        enabled: false
+      quick_facts_list_of_facts:
+        weight: 69
+        enabled: false
+      related_stories:
+        weight: 70
+        enabled: false
+      show_hide_toggle:
+        weight: 71
+        enabled: false
+      slide:
+        weight: 72
+        enabled: false
+      stories:
+        weight: 73
+        enabled: false
+      subhead:
+        weight: 74
+        enabled: false
+      two_col_copy:
+        weight: 75
+        enabled: false
+      two_value_text:
+        weight: 76
+        enabled: false
+field_type: entity_reference_revisions

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.icon_list.field_icon_list_items_small.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.icon_list.field_icon_list_items_small.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_icon_list_items_small
+    - paragraphs.paragraphs_type.icon_list
+id: paragraph.icon_list.field_icon_list_items_small
+field_name: field_icon_list_items_small
+entity_type: paragraph
+bundle: icon_list
+label: 'Small Size'
+description: "For <b>Small Size</b>: We recommend using <em>only</em> the <b>Headline</b>, <b>Description</b> or <b>Link</b>.<br>\r\nThe <b>Default Size</b>: has a larger icon and can accommodate any combination of <b>Headline</b>, <b>Description</b> or <b>Link</b>.  \r\n\r\n<img src=\"https://www.du.edu/themes/custom/pl_drupal/images/admin/helper-images/icon-list.png\">"
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: '1'
+  off_label: '0'
+field_type: boolean

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.image_with_caption.field_image_caption_alignment.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.image_with_caption.field_image_caption_alignment.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image_caption_alignment
+    - paragraphs.paragraphs_type.image_with_caption
+  module:
+    - options
+_core:
+  default_config_hash: Lf7DbL3dTeL3JUYOyW7I9SoRacxEZTWEts5gAkx8_T8
+id: paragraph.image_with_caption.field_image_caption_alignment
+field_name: field_image_caption_alignment
+entity_type: paragraph
+bundle: image_with_caption
+label: Alignment
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: center
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.image_with_caption.field_image_caption_caption.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.image_with_caption.field_image_caption_caption.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image_caption_caption
+    - paragraphs.paragraphs_type.image_with_caption
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    rich_text: rich_text
+    plain_text: plain_text
+    embed_code: '0'
+    inline_formatting: '0'
+_core:
+  default_config_hash: YlyU8fM4uvBK062TsidNBruUuMnCAbsk_87ztyPjS9I
+id: paragraph.image_with_caption.field_image_caption_caption
+field_name: field_image_caption_caption
+entity_type: paragraph
+bundle: image_with_caption
+label: Caption
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.image_with_caption.field_image_caption_float.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.image_with_caption.field_image_caption_float.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image_caption_float
+    - paragraphs.paragraphs_type.image_with_caption
+_core:
+  default_config_hash: xxrWNso6NySvNYfo6Zy6QGa5xWISNdekSJVRvLUotXM
+id: paragraph.image_with_caption.field_image_caption_float
+field_name: field_image_caption_float
+entity_type: paragraph
+bundle: image_with_caption
+label: Float
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.image_with_caption.field_image_caption_image.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.image_with_caption.field_image_caption_image.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image_caption_image
+    - paragraphs.paragraphs_type.image_with_caption
+  module:
+    - image
+_core:
+  default_config_hash: XNGYyVWNlTdsv7WUUiQhml_8V2Gr6FL8hy8U3D8_wCQ
+id: paragraph.image_with_caption.field_image_caption_image
+field_name: field_image_caption_image
+entity_type: paragraph
+bundle: image_with_caption
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: image-caption
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.list_of_links.field_list_of_links.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.list_of_links.field_list_of_links.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_list_of_links
+    - paragraphs.paragraphs_type.list_of_links
+  module:
+    - link
+_core:
+  default_config_hash: Y_AY1ILEM4rQ1PW8RF-xBZjnGtA0uaq7BZhWxcUxMlI
+id: paragraph.list_of_links.field_list_of_links
+field_name: field_list_of_links
+entity_type: paragraph
+bundle: list_of_links
+label: Links
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.list_of_links.field_list_of_links_layout.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.list_of_links.field_list_of_links_layout.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_list_of_links_layout
+    - paragraphs.paragraphs_type.list_of_links
+  module:
+    - options
+_core:
+  default_config_hash: KdGeFp0TWFVUkN3X1l8SnznYXuyLipZ3gCfemrZgjVI
+id: paragraph.list_of_links.field_list_of_links_layout
+field_name: field_list_of_links_layout
+entity_type: paragraph
+bundle: list_of_links
+label: Layout
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: one-col
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.list_of_links.field_list_of_links_style.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.list_of_links.field_list_of_links_style.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_list_of_links_style
+    - paragraphs.paragraphs_type.list_of_links
+  module:
+    - options
+_core:
+  default_config_hash: q47eo4NJT1xxtkTh01xg0HN9T-Hu6-uBo0yysa0PpBg
+id: paragraph.list_of_links.field_list_of_links_style
+field_name: field_list_of_links_style
+entity_type: paragraph
+bundle: list_of_links
+label: Style
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: list-of-links
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.named_anchor.field_named_anchor_name.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.named_anchor.field_named_anchor_name.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_named_anchor_name
+    - paragraphs.paragraphs_type.named_anchor
+_core:
+  default_config_hash: 3W1YyDHMohdh4iBEyKbGyObs6iSL1zibbhZN0STdOc8
+id: paragraph.named_anchor.field_named_anchor_name
+field_name: field_named_anchor_name
+entity_type: paragraph
+bundle: named_anchor
+label: Name
+description: 'Specify named anchor. You must not use blank space in the name. ID tokens must begin with a letter ([A-Za-z]) and may be followed by any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), and periods (".").'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.reusable_content.field_reusable_content.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.reusable_content.field_reusable_content.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_reusable_content
+    - node.type.reusable_content_block
+    - paragraphs.paragraphs_type.reusable_content
+id: paragraph.reusable_content.field_reusable_content
+field_name: field_reusable_content
+entity_type: paragraph
+bundle: reusable_content
+label: 'Reusable content'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      reusable_content_block: reusable_content_block
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_carousel.field_unit_carousel_slide.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_carousel.field_unit_carousel_slide.yml
@@ -1,0 +1,263 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_carousel_slide
+    - paragraphs.paragraphs_type.unit_carousel
+    - paragraphs.paragraphs_type.unit_slide
+  module:
+    - entity_reference_revisions
+_core:
+  default_config_hash: pUZKgP63NqfOsZAJD7EY_QPvQH48E3Sz1sKf3hRMjL0
+id: paragraph.unit_carousel.field_unit_carousel_slide
+field_name: field_unit_carousel_slide
+entity_type: paragraph
+bundle: unit_carousel
+label: Slide
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      unit_slide: unit_slide
+    negate: 0
+    target_bundles_drag_drop:
+      academic_programs:
+        weight: 78
+        enabled: false
+      academic_programs_filter:
+        weight: 79
+        enabled: false
+      academic_programs_legend_def:
+        weight: 80
+        enabled: false
+      admission_steps:
+        weight: 81
+        enabled: false
+      admission_steps_in_content:
+        weight: 82
+        enabled: false
+      application_card:
+        weight: 83
+        enabled: false
+      application_information:
+        weight: 84
+        enabled: false
+      article_list:
+        weight: 85
+        enabled: false
+      big_button:
+        weight: 86
+        enabled: false
+      block:
+        weight: 87
+        enabled: false
+      body_copy:
+        weight: 88
+        enabled: false
+      body_text:
+        weight: 89
+        enabled: false
+      button:
+        weight: 90
+        enabled: false
+      button_with_image:
+        weight: 91
+        enabled: false
+      card:
+        weight: 92
+        enabled: false
+      cards:
+        weight: 93
+        enabled: false
+      carousel:
+        weight: 94
+        enabled: false
+      category_link:
+        weight: 95
+        enabled: false
+      category_menu:
+        weight: 96
+        enabled: false
+      contact:
+        weight: 97
+        enabled: false
+      contact_single:
+        weight: 98
+        enabled: false
+      contacts:
+        weight: 99
+        enabled: false
+      cta:
+        weight: 100
+        enabled: false
+      cta_group:
+        weight: 101
+        enabled: false
+      cta_inline:
+        weight: 102
+        enabled: false
+      embed_code:
+        weight: 103
+        enabled: false
+      event_list:
+        weight: 104
+        enabled: false
+      event_time_place:
+        weight: 105
+        enabled: false
+      expanding_list:
+        weight: 106
+        enabled: false
+      feature_media:
+        weight: 107
+        enabled: false
+      feature_media_image:
+        weight: 108
+        enabled: false
+      feature_media_video:
+        weight: 109
+        enabled: false
+      featured_article:
+        weight: 110
+        enabled: false
+      featured_articles:
+        weight: 111
+        enabled: false
+      featured_event:
+        weight: 112
+        enabled: false
+      featured_event_slide:
+        weight: 113
+        enabled: false
+      featured_video_component:
+        weight: 114
+        enabled: false
+      heading:
+        weight: 115
+        enabled: false
+      hero_media:
+        weight: 116
+        enabled: false
+      hero_media_no_caption:
+        weight: 117
+        enabled: false
+      homepage_facts:
+        weight: 118
+        enabled: false
+      homepage_programs_search:
+        weight: 119
+        enabled: false
+      homepage_quote:
+        weight: 120
+        enabled: false
+      homepage_quotes:
+        weight: 121
+        enabled: false
+      homepage_section_copy:
+        weight: 122
+        enabled: false
+      homepage_swapping_image_feature:
+        weight: 123
+        enabled: false
+      homepage_video_carousel:
+        weight: 124
+        enabled: false
+      hvc_slide:
+        weight: 125
+        enabled: false
+      icon_link:
+        weight: 126
+        enabled: false
+      icon_list:
+        weight: 127
+        enabled: false
+      icon_list_item:
+        weight: 128
+        enabled: false
+      image_with_caption:
+        weight: 129
+        enabled: false
+      inset_video:
+        weight: 130
+        enabled: false
+      key_faculty_and_students:
+        weight: 131
+        enabled: false
+      list_of_links:
+        weight: 132
+        enabled: false
+      named_anchor:
+        weight: 133
+        enabled: false
+      profile_performances:
+        weight: 134
+        enabled: false
+      pull_quote:
+        weight: 135
+        enabled: false
+      quick_facts:
+        weight: 136
+        enabled: false
+      quick_facts_feature_fact:
+        weight: 137
+        enabled: false
+      quick_facts_list_item_simple:
+        weight: 138
+        enabled: false
+      quick_facts_list_of_facts:
+        weight: 139
+        enabled: false
+      quick_stat:
+        weight: 140
+        enabled: false
+      quick_stats:
+        weight: 141
+        enabled: false
+      related_stories:
+        weight: 142
+        enabled: false
+      resource_list:
+        weight: 143
+        enabled: false
+      shared_content_block:
+        weight: 144
+        enabled: false
+      show_hide_toggle:
+        weight: 145
+        enabled: false
+      slide:
+        weight: 146
+        enabled: false
+      social_media_bar:
+        weight: 147
+        enabled: false
+      stories:
+        weight: 148
+        enabled: false
+      subhead:
+        weight: 149
+        enabled: false
+      testimonials_spotlight:
+        weight: 150
+        enabled: false
+      two_col_copy:
+        weight: 151
+        enabled: false
+      two_value_text:
+        weight: 152
+        enabled: false
+      unit_carousel:
+        weight: 153
+        enabled: false
+      unit_slide:
+        weight: 155
+        enabled: true
+      webform:
+        weight: 154
+        enabled: false
+field_type: entity_reference_revisions

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_carousel.field_unit_carousel_title.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_carousel.field_unit_carousel_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_carousel_title
+    - paragraphs.paragraphs_type.unit_carousel
+_core:
+  default_config_hash: hl1wTIfIPU7Qz-rrioQqf4tTnWIb4ElQkDItK9Lcf1k
+id: paragraph.unit_carousel.field_unit_carousel_title
+field_name: field_unit_carousel_title
+entity_type: paragraph
+bundle: unit_carousel
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_hero_media_.field_unit_hero_caption.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_hero_media_.field_unit_hero_caption.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_hero_caption
+    - paragraphs.paragraphs_type.unit_hero_media_
+id: paragraph.unit_hero_media_.field_unit_hero_caption
+field_name: field_unit_hero_caption
+entity_type: paragraph
+bundle: unit_hero_media_
+label: 'Unit Hero Caption'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_hero_media_.field_unit_hero_display.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_hero_media_.field_unit_hero_display.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_hero_display
+    - paragraphs.paragraphs_type.unit_hero_media_
+  module:
+    - options
+id: paragraph.unit_hero_media_.field_unit_hero_display
+field_name: field_unit_hero_display
+entity_type: paragraph
+bundle: unit_hero_media_
+label: 'Unit Hero Display'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_hero_media_.field_unit_hero_embed.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_hero_media_.field_unit_hero_embed.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_hero_embed
+    - paragraphs.paragraphs_type.unit_hero_media_
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    embed_code: embed_code
+    rich_text: '0'
+    inline_formatting: '0'
+    plain_text: '0'
+id: paragraph.unit_hero_media_.field_unit_hero_embed
+field_name: field_unit_hero_embed
+entity_type: paragraph
+bundle: unit_hero_media_
+label: 'Unit Hero Embed'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_hero_media_.field_unit_image_type.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.field.paragraph.unit_hero_media_.field_unit_image_type.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_image_type
+    - paragraphs.paragraphs_type.unit_hero_media_
+id: paragraph.unit_hero_media_.field_unit_image_type
+field_name: field_unit_image_type
+entity_type: paragraph
+bundle: unit_hero_media_
+label: 'Unit image type'
+description: 'Selecting the checkbox will set the hero image to a 1356 x 250.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Short image'
+  off_label: Standard
+field_type: boolean

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_cta_inline_headline.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_cta_inline_headline.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+_core:
+  default_config_hash: Q2A2BMW7l4SQTWa5d1FHUMo54i1Uy1aos4jlblg6TDs
+id: paragraph.field_cta_inline_headline
+field_name: field_cta_inline_headline
+entity_type: paragraph
+type: string
+settings:
+  max_length: 400
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_du_icon.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_du_icon.yml
@@ -1,0 +1,63 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_du_icon
+field_name: field_du_icon
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    attention-circled: 'attention circled'
+    block: 'Block'
+    calendar-empty: 'Calendar empty'
+    calendar-plus-o: 'Calendar plus o'
+    calendar: 'Calendar'
+    check: 'Check'
+    clock: 'Clock'
+    cust-clipboard: 'Cust clipboard'
+    cust-close: 'Cust close'
+    cust-left-arrow: 'Cust left arrow'
+    cust-menu: 'Cust menu'
+    cust-right-arrow: 'Cust right arrow'
+    cust-search: 'Cust search'
+    down-arrow: 'Down arrow'
+    facebook: 'Facebook'
+    fax: 'Fax'
+    globe: 'Globe'
+    gplus: 'Gplus'
+    info-circled: 'Info circled'
+    instagram: 'Instagram'
+    left-arrow: 'Left arrow'
+    link-ext-alt: 'Link ext alt'
+    linkedin: 'Linkedin'
+    location: 'Location'
+    logout: 'Logout'
+    mail-alt: 'Mail alt'
+    mail: 'Mail'
+    minus: 'Minus'
+    newspaper: 'Newspaper'
+    pause-circled: 'Pause circled'
+    phone: 'Phone'
+    play-circled: 'PLAY circled'
+    play-circled2: 'Play circled2'
+    plus: 'Plus'
+    print: 'Print'
+    rebel: 'Rebel'
+    right-arrow: 'Right arrow'
+    snapchat: 'Snapchat'
+    spin3: 'Spin3'
+    tumblr: 'Tumblr'
+    twitter: 'Twitter'
+    up-arrow: 'Up arrow'
+    youtube: 'Youtube'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_feature_media_image.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_feature_media_image.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+_core:
+  default_config_hash: Rj50f6dZy4Yk-6MGKuuYYPL3njWWpMg6Rydv2TlndZg
+id: paragraph.field_feature_media_image
+field_name: field_feature_media_image
+entity_type: paragraph
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_hero_image.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_hero_image.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+_core:
+  default_config_hash: UZiNPUWnh1HbxHywsqDSMvgzRr_lZLCwPupB3alfUIM
+id: paragraph.field_hero_image
+field_name: field_hero_image
+entity_type: paragraph
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_hero_video.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_hero_video.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - paragraphs
+_core:
+  default_config_hash: iMLtRuEkA0mppHcYtFXW85VOG_l1Cb36Uo4fL3AwblM
+id: paragraph.field_hero_video
+field_name: field_hero_video
+entity_type: paragraph
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_icon_link_link.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_icon_link_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_icon_link_link
+field_name: field_icon_link_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_icon_list_items.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_icon_list_items.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+_core:
+  default_config_hash: bYnIqIBh5LxyTGLZEXnNPpeumolpz8hSZ0xzTvfj-PA
+id: paragraph.field_icon_list_items
+field_name: field_icon_list_items
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_icon_list_items_small.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_icon_list_items_small.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_icon_list_items_small
+field_name: field_icon_list_items_small
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_image_caption_alignment.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_image_caption_alignment.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+_core:
+  default_config_hash: d60N1w-DCLXF3RaxSwJZXIN9a1fWxyWZAx5akWBH__Y
+id: paragraph.field_image_caption_alignment
+field_name: field_image_caption_alignment
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    right: 'Right'
+    left: 'Left'
+    center: 'Center'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_image_caption_caption.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_image_caption_caption.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+_core:
+  default_config_hash: Td0oW0AgxxAP1-3-cphKfVGFMLBXsipqGlAqk7AU-uM
+id: paragraph.field_image_caption_caption
+field_name: field_image_caption_caption
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_image_caption_float.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_image_caption_float.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+_core:
+  default_config_hash: B-lRfode4ND-BYmuGbTqtwzGulZuwvpRO_UbDMyEbeE
+id: paragraph.field_image_caption_float
+field_name: field_image_caption_float
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_image_caption_image.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_image_caption_image.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - paragraphs
+_core:
+  default_config_hash: SLTovEfm_lLsttjts1OWcjMv3P1uMWn8kXHNXPu_WiU
+id: paragraph.field_image_caption_image
+field_name: field_image_caption_image
+entity_type: paragraph
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_list_of_links.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_list_of_links.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+_core:
+  default_config_hash: 0VWrRuRIdKxQwSsQaqkVhcz9Mc7LAsuRvipFJ0Xy2rY
+id: paragraph.field_list_of_links
+field_name: field_list_of_links
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_list_of_links_layout.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_list_of_links_layout.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+_core:
+  default_config_hash: YTvRYHVIyjMRfoL_4egPgtTl04DgkdhyzF2a7RCTfSo
+id: paragraph.field_list_of_links_layout
+field_name: field_list_of_links_layout
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    one-col: 'Single Column'
+    two-col: 'Two Column'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_list_of_links_style.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_list_of_links_style.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+_core:
+  default_config_hash: YTOvoivH9nDGHqp1ikK4zCDq94lBmojDq9GczgZYtMA
+id: paragraph.field_list_of_links_style
+field_name: field_list_of_links_style
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    list-of-links: 'Links'
+    normal: 'Bulleted'
+    list-of-links--alt: 'Buttons'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_named_anchor_name.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_named_anchor_name.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+_core:
+  default_config_hash: CqRjm9GFj06puQMmwgJrH8sRVZkuBQQfmyHCS46Zov0
+id: paragraph.field_named_anchor_name
+field_name: field_named_anchor_name
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_reusable_content.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_reusable_content.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_reusable_content
+field_name: field_reusable_content
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_subhead_long.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_subhead_long.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+_core:
+  default_config_hash: EkrVntTnSO_MtSah05PvyEDbFAzgqo79dxYpVRa3ax4
+id: paragraph.field_subhead_long
+field_name: field_subhead_long
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_carousel_slide.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_carousel_slide.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+_core:
+  default_config_hash: CLNVrKTk4t7hIaO1Drm-xANhdlPbp2wf6ibjz15gw74
+id: paragraph.field_unit_carousel_slide
+field_name: field_unit_carousel_slide
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_carousel_title.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_carousel_title.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+_core:
+  default_config_hash: ANio72L8o7bqnMogSg6DTYPjLPQ10TTT-7XDV22anIs
+id: paragraph.field_unit_carousel_title
+field_name: field_unit_carousel_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_hero_caption.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_hero_caption.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_hero_caption
+field_name: field_unit_hero_caption
+entity_type: paragraph
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_hero_display.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_hero_display.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_unit_hero_display
+field_name: field_unit_hero_display
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: default
+      label: Default
+    -
+      value: content-center
+      label: 'Content Center'
+    -
+      value: content-bottom
+      label: 'Content Bottom'
+    -
+      value: content-card
+      label: 'Content Card'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_hero_embed.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_hero_embed.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_unit_hero_embed
+field_name: field_unit_hero_embed
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_image_type.yml
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/config/install/field.storage.paragraph.field_unit_image_type.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_image_type
+field_name: field_unit_image_type
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/ducore/modules/custom/du_paragraphs/du_paragraphs.install
+++ b/web/profiles/custom/ducore/modules/custom/du_paragraphs/du_paragraphs.install
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * Add field storage configurations.
+ */
+function du_paragraphs_update_9001() {
+  $storage_config_ids = array(
+    'field.storage.paragraph.field_cta_inline_headline',
+    'field.storage.paragraph.field_du_icon',
+    'field.storage.paragraph.field_feature_media_image',
+    'field.storage.paragraph.field_heading',
+    'field.storage.paragraph.field_hero_image',
+    'field.storage.paragraph.field_hero_video',
+    'field.storage.paragraph.field_icon_link_link',
+    'field.storage.paragraph.field_icon_list_items',
+    'field.storage.paragraph.field_icon_list_items_small',
+    'field.storage.paragraph.field_image_caption_alignment',
+    'field.storage.paragraph.field_image_caption_caption',
+    'field.storage.paragraph.field_image_caption_float',
+    'field.storage.paragraph.field_image_caption_image',
+    'field.storage.paragraph.field_link',
+    'field.storage.paragraph.field_list_of_links',
+    'field.storage.paragraph.field_list_of_links_layout',
+    'field.storage.paragraph.field_list_of_links_style',
+    'field.storage.paragraph.field_named_anchor_name',
+    'field.storage.paragraph.field_reusable_content',
+    'field.storage.paragraph.field_subhead_long',
+    'field.storage.paragraph.field_unit_carousel_slide',
+    'field.storage.paragraph.field_unit_carousel_title',
+    'field.storage.paragraph.field_unit_hero_caption',
+    'field.storage.paragraph.field_unit_hero_display',
+    'field.storage.paragraph.field_unit_hero_embed',
+    'field.storage.paragraph.field_unit_image_type'
+  );
+
+  foreach ($storage_config_ids as $config_id) {
+    try {
+      $config_path = \Drupal::service('extension.list.module')->getPath('du_paragraphs') . '/config/install/' . $config_id . '.yml';
+
+      if (!file_exists($config_path)) {
+        \Drupal::logger('du_paragraphs')->error('Configuration file not found: @path', ['@path' => $config_path]);
+        continue;
+      }
+
+      $data = \Symfony\Component\Yaml\Yaml::parseFile($config_path);
+
+      // Check if the field storage already exists
+      $existing_storage = \Drupal::entityTypeManager()
+        ->getStorage('field_storage_config')
+        ->load($data['id']);
+
+      if ($existing_storage) {
+        \Drupal::logger('du_paragraphs')->notice('Field storage already exists: @id', ['@id' => $data['id']]);
+        continue;
+      }
+
+      // Create a new field storage config entity
+      $field_storage_config = \Drupal::entityTypeManager()
+        ->getStorage('field_storage_config')
+        ->create($data);
+
+      $field_storage_config->save();
+      \Drupal::logger('du_paragraphs')->notice('Created field storage: @id', ['@id' => $data['id']]);
+
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('du_paragraphs')->error('Error creating field storage @id: @error', [
+        '@id' => $config_id,
+        '@error' => $e->getMessage(),
+      ]);
+      continue;
+    }
+  }
+}
+
+/**
+ * Add field instance configurations.
+ */
+function du_paragraphs_update_9002() {
+  $field_config_ids = array(
+    'field.field.paragraph.cta.field_subhead_long',
+    'field.field.paragraph.cta_inline.field_cta_inline_headline',
+    'field.field.paragraph.cta_inline.field_link',
+    'field.field.paragraph.feature_media_image.field_feature_media_image',
+    'field.field.paragraph.hero_media.field_hero_image',
+    'field.field.paragraph.hero_media.field_hero_video',
+    'field.field.paragraph.icon_link.field_du_icon',
+    'field.field.paragraph.icon_link.field_icon_link_link',
+    'field.field.paragraph.icon_list.field_icon_list_items',
+    'field.field.paragraph.icon_list.field_icon_list_items_small',
+    'field.field.paragraph.image_with_caption.field_image_caption_alignment',
+    'field.field.paragraph.image_with_caption.field_image_caption_caption',
+    'field.field.paragraph.image_with_caption.field_image_caption_float',
+    'field.field.paragraph.image_with_caption.field_image_caption_image',
+    'field.field.paragraph.list_of_links.field_list_of_links',
+    'field.field.paragraph.list_of_links.field_list_of_links_layout',
+    'field.field.paragraph.list_of_links.field_list_of_links_style',
+    'field.field.paragraph.named_anchor.field_named_anchor_name',
+    'field.field.paragraph.reusable_content.field_reusable_content',
+    'field.field.paragraph.unit_carousel.field_unit_carousel_slide',
+    'field.field.paragraph.unit_carousel.field_unit_carousel_title',
+    'field.field.paragraph.unit_hero_media_.field_unit_hero_caption',
+    'field.field.paragraph.unit_hero_media_.field_unit_hero_display',
+    'field.field.paragraph.unit_hero_media_.field_unit_hero_embed',
+    'field.field.paragraph.unit_hero_media_.field_unit_image_type'
+  );
+
+  foreach ($field_config_ids as $config_id) {
+    try {
+      $config_path = \Drupal::service('extension.list.module')->getPath('du_paragraphs') . '/config/install/' . $config_id . '.yml';
+
+      if (!file_exists($config_path)) {
+        \Drupal::logger('du_paragraphs')->error('Configuration file not found: @path', ['@path' => $config_path]);
+        continue;
+      }
+
+      $data = \Symfony\Component\Yaml\Yaml::parseFile($config_path);
+
+      // Check if the field already exists
+      $existing_field = \Drupal::entityTypeManager()
+        ->getStorage('field_config')
+        ->load($data['id']);
+
+      if ($existing_field) {
+        \Drupal::logger('du_paragraphs')->notice('Field config already exists: @id', ['@id' => $data['id']]);
+        continue;
+      }
+
+      // Create a new field config entity
+      $field_config = \Drupal::entityTypeManager()
+        ->getStorage('field_config')
+        ->create($data);
+
+      $field_config->save();
+      \Drupal::logger('du_paragraphs')->notice('Created field config: @id', ['@id' => $data['id']]);
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('du_paragraphs')->error('Error creating field config @id: @error', [
+        '@id' => $config_id,
+        '@error' => $e->getMessage(),
+      ]);
+      continue;
+    }
+  }
+}
+
+/**
+ * Add form and view display configurations.
+ */
+function du_paragraphs_update_9003() {
+  $display_config_ids = array(
+    'core.entity_form_display.paragraph.category_link.default',
+    'core.entity_view_display.paragraph.category_link.default',
+    'core.entity_form_display.paragraph.cta.default',
+    'core.entity_view_display.paragraph.cta.default',
+    'core.entity_form_display.paragraph.cta_inline.default',
+    'core.entity_view_display.paragraph.cta_inline.default',
+    'core.entity_form_display.paragraph.feature_media_image.default',
+    'core.entity_view_display.paragraph.feature_media_image.default',
+    'core.entity_form_display.paragraph.hero_media.default',
+    'core.entity_view_display.paragraph.hero_media.default',
+    'core.entity_form_display.paragraph.icon_link.default',
+    'core.entity_view_display.paragraph.icon_link.default',
+    'core.entity_form_display.paragraph.icon_list.default',
+    'core.entity_view_display.paragraph.icon_list.default',
+    'core.entity_form_display.paragraph.image_with_caption.default',
+    'core.entity_view_display.paragraph.image_with_caption.default',
+    'core.entity_form_display.paragraph.inset_video.default',
+    'core.entity_view_display.paragraph.inset_video.default',
+    'core.entity_form_display.paragraph.list_of_links.default',
+    'core.entity_view_display.paragraph.list_of_links.default',
+    'core.entity_form_display.paragraph.named_anchor.default',
+    'core.entity_view_display.paragraph.named_anchor.default',
+    'core.entity_form_display.paragraph.reusable_content.default',
+    'core.entity_view_display.paragraph.reusable_content.default',
+    'core.entity_form_display.paragraph.unit_carousel.default',
+    'core.entity_view_display.paragraph.unit_carousel.default',
+    'core.entity_form_display.paragraph.unit_hero_media_.default',
+    'core.entity_view_display.paragraph.unit_hero_media_.default'
+  );
+
+  foreach ($display_config_ids as $config_id) {
+    try {
+      $config_path = \Drupal::service('extension.list.module')->getPath('du_paragraphs') . '/config/install/' . $config_id . '.yml';
+
+      if (!file_exists($config_path)) {
+        \Drupal::logger('du_paragraphs')->error('Configuration file not found: @path', ['@path' => $config_path]);
+        continue;
+      }
+
+      $data = \Symfony\Component\Yaml\Yaml::parseFile($config_path);
+
+      // Check if the display config already exists
+      $existing_display = \Drupal::configFactory()->get($config_id);
+      if (!$existing_display->isNew()) {
+        \Drupal::logger('du_paragraphs')->notice('Display config already exists: @id', ['@id' => $config_id]);
+        continue;
+      }
+
+      // Create the new display config
+      \Drupal::configFactory()
+        ->getEditable($config_id)
+        ->setData($data)
+        ->save(TRUE);
+
+      \Drupal::logger('du_paragraphs')->notice('Created display config: @id', ['@id' => $config_id]);
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('du_paragraphs')->error('Error creating display config @id: @error', [
+        '@id' => $config_id,
+        '@error' => $e->getMessage(),
+      ]);
+      continue;
+    }
+  }
+}


### PR DESCRIPTION
This helps fresh sites get the fields/displays for Paragraphs inside the du_paragraphs module if they do not have them.

Also includes some logging in case a config file exists already, cannot be found, etc.