### PR TITLE
add basic test for D9 sites for CKEditor media embed

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,7 +45,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Playwright tests
-        run: npx playwright test
+        run: npx playwright test --grep-invert "@d9"
 
       - name: Upload Playwright report
         if: always()

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -91,11 +91,23 @@ Any support files used by the tests should be stored here.
 - `files.ts` - Support for working with files.
 - `users.ts` - Use this for working with users in tests including login/logout methods.
 
-## Todos
+## Testing Live Pantheon Sites
 
-These would be good things to add to the tests:
+In order to help with testing on Pantheon, you can use this test suite to target runs against 
+a Pantheon site. 
 
-- [ ] Implement cookie-based login https://medium.com/automated-monotony/using-playwright-cookies-to-bypass-authentication-b5eb29b35c73
-- [ ] Possibly move bootstrap scripts to DDEV commands
-- [ ] Add the ability to run drush commands via the support helper files
-- [ ] Stop CI run on first test failure
+Tests tagged with `@d9` will run against a D9 site, and since CKEditor 5 is enabled on the D9 
+sites, the same test helpers can be used for testing the D10 profile.
+
+You can run the tests against a Pantheon site by setting the `BASE_URL` environment variable to 
+the site's URL.
+
+```bash
+BASE_URL="https://www-du-core.ddev.site/" npx playwright test --grep @d9
+```
+
+### Run Tests Against All Dev/Test Sites
+
+Before a deployment, it can be useful to run the tests against all the Dev or Test sites.
+
+

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -100,10 +100,14 @@ Tests tagged with `@d9` will run against a D9 site, and since CKEditor 5 is enab
 sites, the same test helpers can be used for testing the D10 profile.
 
 You can run the tests against a Pantheon site by setting the `BASE_URL` environment variable to 
-the site's URL.
+the site's URL, but make sure that the QA features are enabled on the site.
 
 ```bash
-BASE_URL="https://www-du-core.ddev.site/" npx playwright test --grep @d9
+# Enable QA features on the Pantheon site.
+terminus drush "du-core.dev" -- en du_functional_testing -y
+
+# Run tests for D9 site on the Pantheon.
+BASE_URL="https://dev-du-core.pantheonsite.io/" npx playwright test --grep @d9
 ```
 
 ### Run Tests Against All Dev/Test Sites

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -108,6 +108,19 @@ BASE_URL="https://www-du-core.ddev.site/" npx playwright test --grep @d9
 
 ### Run Tests Against All Dev/Test Sites
 
-Before a deployment, it can be useful to run the tests against all the Dev or Test sites.
+Before a deployment, it can be useful to run the tests against all the Dev or Test sites. To 
+make the sites more like production, some commands need to be run to sync the database and turn 
+on QA features.
+
+```bash
+cd tests/playwright/scripts
+
+# Sync db and enable QA features for all dev sites.
+./sync-db-from-live.sh dev
+./enable-qa-features.sh dev
+
+# Run tests tagged "@d9" against all dev sites.
+./test-sites.sh @d9 dev
+```
 
 

--- a/tests/playwright/e2e/d9-sites/base/ckeditor.spec.ts
+++ b/tests/playwright/e2e/d9-sites/base/ckeditor.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@du_pw/test';
+import { faker } from '@faker-js/faker';
+
+import {createAnonSession, getRole, logIn} from "@du_pw/support/users";
+import {drush} from "@du_pw/support/drush";
+import {verifyCKEditorPluginsVisible} from "@du_pw/support/content";
+
+test.describe('@d9 @CKE - Basic CKEditor Tests', () => {
+  const admin = getRole('administrator');
+  const page_title = faker.lorem.words(3);
+
+  test('Test Media Embed', async ({ page, context }) => {
+    await logIn(page, context, admin);
+    await page.goto('/node/add/page');
+
+    await page.getByRole('textbox', {name: 'Title', exact: true}).fill(page_title);
+
+    // Open CKEditor.
+    await page.locator('div[data-drupal-selector="edit-field-page-overview"]')
+      .getByRole('button', { name: 'Add Body Text', exact: true })
+      .click();
+
+    // Varify plugins exist and are visible.
+    // If there is a JS error breaking the WYSIWYG, the test will fail.
+    await verifyCKEditorPluginsVisible(page, 'edit-field-page-overview-0',
+      [
+        'Undo',
+        'Redo',
+        'Bold',
+        'Italic',
+        'Link',
+        'Bulleted List',
+        // Dropdown causes two "Numbered List" matches.
+        // 'Numbered List',
+        'Text alignment',
+        'File Browser',
+        'Media Embed',
+        'Insert media',
+        'Block quote',
+        'Insert table',
+        // Can't find the source button for some reason.
+        // 'Source'
+      ]);
+
+    // Open media embed plugin.
+    const fieldWrapper = page.locator('[data-drupal-selector="edit-field-page-overview-0"]');
+    const toolbar = fieldWrapper.getByRole('toolbar', { name: 'Editor toolbar' });
+    await toolbar.getByRole('button', { name: 'Media Embed' }).click();
+
+    // Wait for the media grid to load, then select the first item.
+    const entityBrowser = page.frameLocator('#entity_browser_iframe_media_browser');
+    await entityBrowser.locator('[data-selectable="true"]').first().click();
+    await entityBrowser.getByRole('button', { name: 'Place' }).click();
+    // Embed the selected media item.
+    await page.locator('.ui-dialog-buttonpane').getByRole('button', { name: 'Embed' }).click();
+
+    // Save page.
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Look for the title.
+    await expect(page.locator('h1')).toHaveText(page_title);
+
+    // Look for the image.
+    await expect(page.locator('#main-content img').first()).toBeVisible();
+  });
+});

--- a/tests/playwright/e2e/d9-sites/base/ckeditor.spec.ts
+++ b/tests/playwright/e2e/d9-sites/base/ckeditor.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from '@du_pw/test';
 import { faker } from '@faker-js/faker';
 
-import {createAnonSession, getRole, logIn} from "@du_pw/support/users";
-import {drush} from "@du_pw/support/drush";
+import {getRole, logIn} from "@du_pw/support/users";
 import {verifyCKEditorPluginsVisible} from "@du_pw/support/content";
 
 test.describe('@d9 @CKE - Basic CKEditor Tests', () => {

--- a/tests/playwright/scripts/enable-qa-on-sites.sh
+++ b/tests/playwright/scripts/enable-qa-on-sites.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Usage: ./enable-qa-on-sites.sh [environment]
+# Example: ./enable-qa-on-sites.sh dev
+
+ENVIRONMENT="${1:-test}"
+
+# Load sites into a variable to avoid stdin conflicts with terminus
+SITES=$(jq -r '.[] | .site' sites.json)
+
+if [ -z "$SITES" ]; then
+  echo "No sites found in sites.json"
+  exit 1
+fi
+
+for SITE in $SITES; do
+  echo "Turning on QA features for: $SITE.$ENVIRONMENT"
+  terminus drush "${SITE}.${ENVIRONMENT}" -- en du_functional_testing -y
+  echo ""
+done

--- a/tests/playwright/scripts/sites.json
+++ b/tests/playwright/scripts/sites.json
@@ -1,0 +1,65 @@
+[
+  {
+    "site": "academic-affairs"
+  },
+  {
+    "site": "alumni1"
+  },
+  {
+    "site": "cahsscore"
+  },
+  {
+    "site": "content1"
+  },
+  {
+    "site": "du-centers"
+  },
+  {
+    "site": "du-core"
+  },
+  {
+    "site": "du-internationalization"
+  },
+  {
+    "site": "du-newman-center"
+  },
+  {
+    "site": "du-student-affairs"
+  },
+  {
+    "site": "du-university-libraries"
+  },
+  {
+    "site": "give1"
+  },
+  {
+    "site": "gspp"
+  },
+  {
+    "site": "gssw"
+  },
+  {
+    "site": "inauguration"
+  },
+  {
+    "site": "lawcore"
+  },
+  {
+    "site": "lawlibrary"
+  },
+  {
+    "site": "morgridge"
+  },
+  {
+    "site": "nsmcore"
+  },
+  {
+    "site": "ritchie"
+  },
+  {
+    "site": "university-college"
+  },
+  {
+    "site": "whydu"
+  }
+]

--- a/tests/playwright/scripts/sync-db-from-live.sh
+++ b/tests/playwright/scripts/sync-db-from-live.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Usage: ./sync-db-from-live.sh [environment]
+# Example: ./sync-db-from-live.sh dev
+
+ENVIRONMENT="${1:-test}"
+
+# Load sites into a variable to avoid stdin conflicts with terminus
+SITES=$(jq -r '.[] | .site' sites.json)
+
+if [ -z "$SITES" ]; then
+  echo "No sites found in sites.json"
+  exit 1
+fi
+
+for SITE in $SITES; do
+  echo "Cloning back db from live to: $SITE.$ENVIRONMENT"
+  terminus env:clone-content "${SITE}.live" "${ENVIRONMENT}" --db-only
+  echo ""
+done

--- a/tests/playwright/scripts/test-sites.sh
+++ b/tests/playwright/scripts/test-sites.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Usage: ./test-sites.sh [tag] [environment]
+# Example: ./test-sites.sh @smoke dev
+
+TAG="${1:-@smoke}"
+ENVIRONMENT="${2:-test}"
+
+jq -r '.[] | .site' sites.json | while read -r SITE; do
+  URL="https://${ENVIRONMENT}-${SITE}.pantheonsite.io/"
+  echo "Testing: $URL"
+  BASE_URL="$URL" npx playwright test --grep "$TAG"
+  echo ""
+done

--- a/tests/playwright/support/content.ts
+++ b/tests/playwright/support/content.ts
@@ -1,5 +1,5 @@
 // These are a work-in-progress for helping with content creation, but not used on any test yet.
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 
 /**
  * Get the CKEditor editable area for a field
@@ -20,4 +20,22 @@ export async function fillParagraphField(
 ): Promise<void> {
   const selector = `[data-drupal-selector="edit-field-page-overview-${paragraphIndex}-subform-${fieldName}-0-value"]`;
   await page.locator(selector).fill(content, { force: true });
+}
+
+export async function verifyCKEditorPluginsVisible(
+  page: Page,
+  fieldSelector: string,
+  expectedPlugins: string[]
+): Promise<void> {
+  const fieldWrapper = page.locator(`[data-drupal-selector="${fieldSelector}"]`);
+  const toolbar = fieldWrapper.getByRole('toolbar', { name: 'Editor toolbar' });
+
+  await expect(toolbar).toBeVisible();
+
+  for (const plugin of expectedPlugins) {
+    await expect(
+      toolbar.getByRole('button', { name: plugin }),
+      `Expected plugin "${plugin}" in field "${fieldSelector}"`
+    ).toBeVisible();
+  }
 }


### PR DESCRIPTION
Wrike tickets:
- CKE 4.x/5.x JS issues - https://www.wrike.com/open.htm?id=4347555524
- CKEditor feature testing - https://www.wrike.com/open.htm?id=1797269767

Still a work in progress, but this PR adds a way to turn on QA features and run a basic media embed test on all the Pantheon D9 sites.